### PR TITLE
prompt engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ curl -X POST http://127.0.0.1:5000/extract-act-frame \
 -d '{"article_string": "personal data shall be processed lawfully."}'
 ```
 
+**Note** that by default, the server mimics processing time by sleeping for 5 - 10 seconds before returning a response. If you want disable this behavior, change the key of your request type to "debug":
+
+```bash
+curl -X POST http://127.0.0.1:5000/extract-act-frame \
+-H "Content-Type: application/json" \
+-d '{"debug": "personal data shall be processed lawfully."}'
+```
+
+
 ## Report:
 - [view only](https://www.overleaf.com/read/vwhrjrsnsxrj#6d5464)
 

--- a/flint_frame_service.py
+++ b/flint_frame_service.py
@@ -1,4 +1,6 @@
 from flask import Flask, jsonify, request
+import time
+import random
 
 
 app = Flask(__name__)
@@ -35,7 +37,8 @@ def data_process():
             "Art. 14 (1) Aliens Act, main clause and under (a)"
         ]
     }
-
+    # wait for 5 - 10 seconds to mimmick processing time
+    time.sleep(random.randint(5, 10))
     return jsonify(response)
 
 def validate_request(request):

--- a/flint_frame_service.py
+++ b/flint_frame_service.py
@@ -37,8 +37,7 @@ def data_process():
             "Art. 14 (1) Aliens Act, main clause and under (a)"
         ]
     }
-    # wait for 5 - 10 seconds to mimmick processing time
-    time.sleep(random.randint(5, 10))
+    # wait for 5 - 10 seconds to mimic processing time
     return jsonify(response)
 
 def validate_request(request):
@@ -51,7 +50,13 @@ def validate_request(request):
 
     # Check if the JSON data contains only one key and the value is a string
     if len(data) == 1 and isinstance(list(data.values())[0], str):
-      return
+        # if key is debug, wait for 5 - 10 seconds
+        if "debug" in data.keys():
+            if data["debug"] == "true":
+                return
+        else:
+            time.sleep(random.randint(5, 10))
+            return
     else:
         return jsonify({"error": "Request JSON must contain exactly one key with a string value"}), 400
 


### PR DESCRIPTION
- add poetry as dependency manager.
- add instructions on using dotenv file.
- add initial notebook.
- wrap OpenAPI client inside SemanticRoleLabeler class to facilicate extending class with helper methods like sentence splitter and output validator.
- downgrade to python 3.9 to unlock compatible torch version and add dependencie for finetuning Bertje.
- Add dependencies, visualizer, and copy over data.
- extract labels as proper list from gpt response.
- refactor: extract utility class.
- add docstrings.
- clean up notebook.
- update readme with instructions on poetry and env vars.
- clean up and catch exception.
- move deprecated files and add demo for v2 prompting (act frames).
- refactor: extract model and add enum for model type.
- use filename as promt identifier.
- add sample frames from alient act paper.
- - move up config vars to top of notebook to faciliate experimentation - add new prompt to elicity chain-of-thought-reasoning - export answer using new prompt and gpt4
- add dependencies to use gemini (google-generativeai package).
- add flask dependency.
- add instructions on running flask server.
- add template for flask server.
- fix inconsistent key names between act frames from different papers.
- add links to sources of norms / act frames.
- add notebook for exploring gemini.
- remove deprecated key.
- add artificial, more complex response.
- add initial openapi spec for main response.
- fix title.
- put in list to be consitent.
- update schema.
- update readme.
- rename service and return dummy response.
- Add random timer before returning request to mimmick processing time; ui should handle these async calls gracefully.
- mimic processing time and allow immediate responses for debugging.
